### PR TITLE
WIM-324 - Demo content fo Behat.

### DIFF
--- a/behat/features/bootstrap/FeatureContext.php
+++ b/behat/features/bootstrap/FeatureContext.php
@@ -7,10 +7,147 @@
 
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
+use Behat\Testwork\Hook\Scope\AfterSuiteScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 
 /**
  * Defines application features from the specific context.
  */
 class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext {
+
+  /**
+   * I wait for (seconds) seconds.
+   *
+   * @When I wait for :arg1 seconds
+   */
+  public function iWaitForSeconds($seconds, $condition = '') {
+    $milliseconds = (int) ($seconds * 1000);
+    $this->getSession()->wait($milliseconds, $condition);
+  }
+
+  /**
+   * This will be run when Behat testing suite is started.
+   *
+   * @BeforeSuite
+   */
+  public static function enableFixtureModules(BeforeSuiteScope $scope) {
+    module_enable(array('migrate', 'wim_fixtures'));
+  }
+
+  /**
+   * This will be run when Behat testing suite is ended.
+   *
+   * @AfterSuite
+   */
+  public static function disableFixtureModules(AfterSuiteScope $scope) {
+    $machine_names = self::getAllFixtureMigrations();
+    self::revertMigrations($machine_names);
+    module_disable(array('migrate', 'wim_fixtures'));
+  }
+
+  /**
+   * This will be run when Behat finds fixtures tag in scenario.
+   *
+   * @BeforeScenario @fixtures
+   */
+  public static function runAllMigrations(BeforeScenarioScope $scope) {
+    $machine_names = self::getAllFixtureMigrations(TRUE);
+    foreach ($machine_names as $machine_name) {
+      self::runMigration($machine_name);
+    }
+  }
+
+  /**
+   * Get all migrations from api.
+   *
+   * @param bool|FALSE $register
+   *   If we should register migration.
+   *
+   * @return array
+   *   Machine names array.
+   */
+  protected static function getAllFixtureMigrations($register = FALSE) {
+    if (!module_exists('wim_fixtures')) {
+      return array();
+    }
+
+    module_load_include('inc', 'wim_fixtures', 'wim_fixtures.migrate');
+    $migrations = wim_fixtures_migrate_api();
+    $machine_names = array();
+    foreach ($migrations['migrations'] as $name => $migration) {
+      $machine_names[] = $name;
+    }
+
+    if ($register) {
+      migrate_static_registration($machine_names);
+    }
+
+    return $machine_names;
+  }
+
+  /**
+   * Just run the migrations.
+   *
+   * @param string $machine_name
+   *   Machine name.
+   *
+   * @throws \Exception
+   */
+  protected static function runMigration($machine_name) {
+    $migration = Migration::getInstance($machine_name);
+    $dependencies = $migration->getHardDependencies();
+    if ($dependencies) {
+      foreach ($dependencies as $name) {
+        self::runMigration($name);
+      }
+    }
+    $migration->processImport();
+  }
+
+  /**
+   * Just revert all migrations.
+   *
+   * @param array $machine_names
+   *   Machine names.
+   *
+   * @throws \Exception
+   */
+  protected static function revertMigrations($machine_names) {
+    $dependencies = array();
+    foreach ($machine_names as $machine_name) {
+      $migration = Migration::getInstance($machine_name);
+      $dependencies += $migration->getDependencies();
+    }
+
+    foreach ($dependencies as $dependency) {
+      $dependencies[$dependency] = $dependency;
+    }
+
+    // First revert top level migrations (no dependencies)
+    foreach ($machine_names as $machine_name) {
+      if (in_array($machine_name, $dependencies)) {
+        continue;
+      }
+      self::revertMigration($machine_name);
+    }
+
+    if ($dependencies) {
+      self::revertMigrations($dependencies);
+    }
+  }
+
+  /**
+   * Revert single migration.
+   *
+   * @param string $machine_name
+   *   Migration name.
+   *
+   * @throws \Exception
+   */
+  protected static function revertMigration($machine_name) {
+    $migration = Migration::getInstance($machine_name);
+    $migration->processRollback(array('force' => TRUE));
+  }
 
 }

--- a/behat/features/capabilities/account/login.feature
+++ b/behat/features/capabilities/account/login.feature
@@ -14,3 +14,11 @@ Feature: Login
         | Password | admin |
     And I press "Log in"
     Then I should see "admin"
+
+  @fixtures
+  Scenario: Check if demo users are there
+    Given I am logged in as a "administrator"
+    And I am on "admin/people"
+    Then I should see the text "active" in the "cm" row
+    And I should see the text "content moderator" in the "cm" row
+    And I should see the text "active" in the "test" row


### PR DESCRIPTION
# HTT:
## how to run demo content manually
- go to `admin/modules`
- enable: `wim_fixtures, migrate, migrate_ui` modules and save
- go to `admin/content/migrate`
- check the box for **WIM Fixtures** and execute **Import**

## how to run demo content using drush
- `docker exec -it wim_web drush en wim_fixtures -y`
- `docker exec -it wim_web drush mi --group=WIMMigrate`

### all behat scenarios with tag @fixtures will run demo content migration automatically on CI server.