### PR TITLE
WIM-1139 by kedramon: Added Logging alerts module.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -35,6 +35,7 @@ projects[hansel] = 1.6
 projects[honeypot] = 1.22
 projects[jquery_update] = 2.7
 projects[location] = 3.7
+projects[logging_alerts] = 2.2
 projects[magic] = 2.2
 projects[media] = 2.0-beta2
 projects[menu_block] = 2.7
@@ -100,7 +101,7 @@ libraries[a11ychecker][download][url] = "http://a11ychecker.download.cksource.co
 libraries[a11ychecker][destination] = "libraries"
 libraries[a11ychecker][subdir] = "ckeditor_plugins"
 
-; CKEditor 4.4.6
+; CKEditor 4.5.11
 libraries[ckeditor][download][type] = get
 libraries[ckeditor][download][url] = http://ckeditor.com/builder/download/4aa56d967057f1cfe925bceb9b98049d
 


### PR DESCRIPTION
# HTT

- Log in ad admin
- go to _admin/modules_
- enable **Email logging and alerts** and **Trigger** modules
- go to _admin/config/system/emaillog_
- comma separated list of emails is alloved
- enter an email address for each severity level you want
- *Info* level contain information for imports and indexing etc.
- after this we need to configure triggers
- go to _admin/config/system/watchdog_triggers_
- for **Message type** field enter comma separated list when to trigger email sending
- name can be found _admin/reports/dblog_ if **Database logging** is enabled in Type column.
- entering `cron, Apache Solr, atos esuite batch report` will trigger when solr indexing site, on cron run and when atos import is running. 
- all this option can be adjusted for own needs