### PR TITLE
WIM-1240: Fix Front page having no H1 and incorrect metatags.

### DIFF
--- a/themes/wimbase/templates/system/page.tpl.php
+++ b/themes/wimbase/templates/system/page.tpl.php
@@ -86,7 +86,9 @@
             <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
           </a>
         <?php endif; ?>
-
+        <?php if ($is_front): ?>
+          <h1 class="element-invisible"><?php print t('Home'); ?></h1>
+        <?php endif; ?>
         <?php if (!empty($site_name)): ?>
           <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
         <?php endif; ?>

--- a/wim.install
+++ b/wim.install
@@ -29,7 +29,7 @@ function wim_install() {
   _wim_install_language();
   // Install password policy.
   _wim_password_policy_install();
-  // Set metatags for Front Page
+  // Set metatags for Front Page.
   _wim_set_front_metatags();
   // Add 404 page.
   $page_404_nid = _wim_create_page('404');
@@ -1066,13 +1066,13 @@ function _wim_permissions($role) {
  */
 function _wim_set_front_metatags() {
   $front_metatags = (object) array(
-        'cid' => NULL,
-        'instance' => 'global:frontpage',
-        'config' => array(
-          'title' => array('value' => '[site:name]'),
-          'canonical' => array('value' => '[site:url]'),
-          'shortlink' => array('value' => '[site:url]'),
-        ),
+    'cid' => NULL,
+    'instance' => 'global:frontpage',
+    'config' => array(
+      'title' => array('value' => '[site:name]'),
+      'canonical' => array('value' => '[site:url]'),
+      'shortlink' => array('value' => '[site:url]'),
+    ),
   );
 
   metatag_config_save($front_metatags);

--- a/wim.install
+++ b/wim.install
@@ -29,7 +29,8 @@ function wim_install() {
   _wim_install_language();
   // Install password policy.
   _wim_password_policy_install();
-
+  // Set metatags for Front Page
+  _wim_set_front_metatags();
   // Add 404 page.
   $page_404_nid = _wim_create_page('404');
   variable_set('site_404', 'node/' . $page_404_nid);
@@ -1058,4 +1059,21 @@ function _wim_permissions($role) {
   }
 
   return $permissions[$role];
+}
+
+/**
+ * Sets front metatags.
+ */
+function _wim_set_front_metatags() {
+  $front_metatags = (object) array(
+        'cid' => NULL,
+        'instance' => 'global:frontpage',
+        'config' => array(
+          'title' => array('value' => '[site:name]'),
+          'canonical' => array('value' => '[site:url]'),
+          'shortlink' => array('value' => '[site:url]'),
+        ),
+  );
+
+  metatag_config_save($front_metatags);
 }

--- a/wim.update.inc
+++ b/wim.update.inc
@@ -140,13 +140,13 @@ function wim_update_7005(&$sandbox) {
 function wim_update_7006(&$sandbox) {
 
   $front_metatags = (object) array(
-        'cid' => NULL,
-        'instance' => 'global:frontpage',
-        'config' => array(
-          'title' => array('value' => '[site:name]'),
-          'canonical' => array('value' => '[site:url]'),
-          'shortlink' => array('value' => '[site:url]'),
-        ),
+    'cid' => NULL,
+    'instance' => 'global:frontpage',
+    'config' => array(
+      'title' => array('value' => '[site:name]'),
+      'canonical' => array('value' => '[site:url]'),
+      'shortlink' => array('value' => '[site:url]'),
+    ),
   );
 
   metatag_config_save($front_metatags);

--- a/wim.update.inc
+++ b/wim.update.inc
@@ -133,3 +133,21 @@ function wim_update_7005(&$sandbox) {
     theme_enable(array($theme_name));
   }
 }
+
+/**
+ * Set correct metatags for Front Page.
+ */
+function wim_update_7006(&$sandbox) {
+
+  $front_metatags = (object) array(
+        'cid' => NULL,
+        'instance' => 'global:frontpage',
+        'config' => array(
+          'title' => array('value' => '[site:name]'),
+          'canonical' => array('value' => '[site:url]'),
+          'shortlink' => array('value' => '[site:url]'),
+        ),
+  );
+
+  metatag_config_save($front_metatags);
+}


### PR DESCRIPTION
# HTT

- [ ] Apply pending updates/reinstall. Clear caches. Proceed to Front page.
- [ ] Check headings structure with any tool (like HeadingsMap), there should be an H1 heading present in headings structure now.
- [ ] Hover over the site tab in a browser, you should see Site Name show up.