### PR TITLE
WIM-1264 - Add display title to the read more link for accesibility

### DIFF
--- a/modules/custom/custom_lists/custom_lists.module
+++ b/modules/custom/custom_lists/custom_lists.module
@@ -132,7 +132,7 @@ function custom_lists_block_view($delta = '') {
     $more_link_uri = custom_lists_get_more_uri($list);
     if ($more_link_uri) {
       $block['content']['more-link'] = array(
-        '#markup' => '<div class="more-link">' . l(t('More') . ' ' . t($list['display_title']), $more_link_uri) . '</div>',
+        '#markup' => '<div class="more-link">' . l(t('More @display_title', array('@display_title' => $list['display_title'])), $more_link_uri) . '</div>',
       );
     }
   }

--- a/modules/custom/custom_lists/custom_lists.module
+++ b/modules/custom/custom_lists/custom_lists.module
@@ -132,7 +132,7 @@ function custom_lists_block_view($delta = '') {
     $more_link_uri = custom_lists_get_more_uri($list);
     if ($more_link_uri) {
       $block['content']['more-link'] = array(
-        '#markup' => '<div class="more-link">' . l(t('More'), $more_link_uri) . '</div>',
+        '#markup' => '<div class="more-link">' . l(t('More') . ' ' . t($list['display_title']), $more_link_uri) . '</div>',
       );
     }
   }


### PR DESCRIPTION
HTT.

When creating a new custom list and adding a block to it which has a read more link, this read more link should be more explanatory by using the display title in it.