### PR TITLE
Fixing notice 

### DIFF
--- a/modules/features/wim_webform/wim_webform.module
+++ b/modules/features/wim_webform/wim_webform.module
@@ -44,7 +44,7 @@ function wim_webform_form_webform_client_form_alter(&$form, $form_state) {
 
       unset($element['#title']);
     }
-    elseif ($element['#title_display'] == 'none') {
+    elseif (isset($element['#title_display']) && $element['#title_display'] === 'none') {
 
       // Wrapping in fieldsets shoudn't happen if component doesn't have a
       // title, but incorrect labels should still be removed.


### PR DESCRIPTION
Fixing notice for webform if it contain markup element or elements without #title_display option.