### PR TITLE
Simplify module and allow to use simple links instead of internal page.

### DIFF
--- a/modules/custom/cookie_consent/cookie_consent.admin.inc
+++ b/modules/custom/cookie_consent/cookie_consent.admin.inc
@@ -16,9 +16,8 @@ function cookie_consent_admin_form() {
 
   $form['cookie_consent_link'] = array(
     '#type' => 'textfield',
-    '#autocomplete_path' => 'cookie-consent/autocomplete/node',
-    '#title' => t('More information Node Link'),
-    '#description' => t("Appends ':link_title' (linking to the selected node) to the bottom of the Cookie Consent banner and privacy tabs. Leave empty to omit this behaviour.", array(
+    '#title' => t('More information Link'),
+    '#description' => t("Appends ':link_title' to the bottom of the Cookie Consent banner and privacy tabs. Provide full or internal url like node/[nid]o or alias. Leave empty to omit this behaviour.", array(
       ':link_title' => $cookie_consent_link_title,
     )),
     '#default_value' => variable_get('cookie_consent_link', ''),
@@ -133,28 +132,4 @@ function cookie_consent_admin_form() {
   }
 
   return system_settings_form($form);
-}
-
-/**
- * AJAX Callback for /cookie_consent/autocomplete/node/%.
- *
- * @param string $string
- *    Title.
- */
-function _cookie_consent_autocomplete_node($string) {
-  $matches = db_select('node', 'n')
-    ->fields('n', array('nid', 'title'))
-    ->condition('n.title', '%' . db_like($string) . '%', 'LIKE')
-    ->condition('n.status', 1)
-    ->execute()
-    ->fetchAll();
-
-  $build = array();
-  foreach ($matches as $match) {
-    $title = check_plain($match->title);
-    $value = sprintf('%s [nid:%s]', $title, $match->nid);
-    $build[$value] = $title;
-  }
-
-  drupal_json_output($build);
 }

--- a/modules/custom/cookie_consent/cookie_consent.install
+++ b/modules/custom/cookie_consent/cookie_consent.install
@@ -77,3 +77,13 @@ function cookie_consent_uninstall() {
     ->condition('name', db_like('cookie_consent_') . '%', 'LIKE')
     ->execute();
 }
+
+/**
+ * Convert link variable to path.
+ */
+function cookie_consent_update_7000(&$sandbox) {
+  $cookie_consent_link = variable_get('cookie_consent_link', FALSE);
+  if ($cookie_consent_link && preg_match('/\[nid:(\d+)\]/', $cookie_consent_link, $matches) && count($matches) > 1 && is_numeric($matches[1])) {
+    variable_set('cookie_consent_link', url('node/' . $matches[1]));
+  }
+}

--- a/modules/custom/cookie_consent/cookie_consent.module
+++ b/modules/custom/cookie_consent/cookie_consent.module
@@ -25,14 +25,6 @@ function cookie_consent_menu() {
     'type' => MENU_CALLBACK,
   );
 
-  $items['cookie-consent/autocomplete/node'] = array(
-    'title' => 'AJAX Autocomplete Node',
-    'access arguments' => array('administer cookie_consent'),
-    'page callback' => '_cookie_consent_autocomplete_node',
-    'file' => 'cookie_consent.admin.inc',
-    'type' => MENU_CALLBACK,
-  );
-
   return $items;
 }
 
@@ -88,10 +80,10 @@ function _cookie_consent_attach(&$page) {
   }
 
   $link = array();
-  $cookie_consent_link = variable_get('cookie_consent_link', FALSE);
-  if ($cookie_consent_link && preg_match('/\[nid:(\d+)\]/', $cookie_consent_link, $matches) && count($matches) > 1 && is_numeric($matches[1])) {
+  $cookie_consent_link = variable_get('cookie_consent_link', '');
+  if ($cookie_consent_link) {
     $link = array(
-      'url' => url('node/' . $matches[1]),
+      'url' => url($cookie_consent_link),
       'title' => check_plain(variable_get('cookie_consent_link_title', t('More information'))),
     );
   }


### PR DESCRIPTION
**Problem/motivation:**

Some sites can have subdomains, and if each subdomain is standalone there is no way to configure more information link to point to main site.

Removed some unneeded functionality, added update hook.