### PR TITLE
Fix overriding summary during import.

### DIFF
--- a/modules/features/atos_esuite/atos_esuite.import.inc
+++ b/modules/features/atos_esuite/atos_esuite.import.inc
@@ -328,7 +328,12 @@ function atos_esuite_map_node_product(stdClass $node, DOMDocument $documentDOM, 
   // Description.
   $description = $xpath->query('/result/beschrijving')->item(0)->nodeValue;
   $body = $description;
-  $summary = truncate_utf8($description, 250);
+  if ($node->body[LANGUAGE_NONE][0]['summary']) {
+    $summary = $node->body[LANGUAGE_NONE][0]['summary'];
+  }
+  else {
+    $summary = truncate_utf8($description, 250);
+  }
 
   // Helper array to map xml tags to fields in node.
   $mapping = array(

--- a/modules/features/atos_esuite/atos_esuite.import.inc
+++ b/modules/features/atos_esuite/atos_esuite.import.inc
@@ -328,7 +328,7 @@ function atos_esuite_map_node_product(stdClass $node, DOMDocument $documentDOM, 
   // Description.
   $description = $xpath->query('/result/beschrijving')->item(0)->nodeValue;
   $body = $description;
-  if ($node->body[LANGUAGE_NONE][0]['summary']) {
+  if (isset($node->body[LANGUAGE_NONE][0]['summary']) && $node->body[LANGUAGE_NONE][0]['summary']) {
     $summary = $node->body[LANGUAGE_NONE][0]['summary'];
   }
   else {


### PR DESCRIPTION
The summary field can be updated or inserted for some products.
During import this information was overridden by trimmed version of body what is unwanted when summary is not empty.