### PR TITLE
WIM-1296 - Add firefox focus on every button for accessibility

### DIFF
--- a/themes/wim/components/wim/atoms/_buttons.scss
+++ b/themes/wim/components/wim/atoms/_buttons.scss
@@ -2,3 +2,7 @@
   background-color: $link-color;
   border-color: $link-hover-color;
 }
+
+.btn:-moz-focusring {
+  outline: 2px dotted;
+}

--- a/themes/wim/css/wim.css
+++ b/themes/wim/css/wim.css
@@ -3142,6 +3142,10 @@ ul[class^="custom-list-view-mode"]:not([class*="title"]) li {
   border-color: #00465c;
 }
 
+.btn:-moz-focusring {
+  outline: 2px dotted;
+}
+
 .nav-tabs {
   border-bottom: 1px solid #ddd;
   margin-top: 10px;

--- a/themes/wim/dist/css/wim.css
+++ b/themes/wim/dist/css/wim.css
@@ -3142,6 +3142,10 @@ ul[class^="custom-list-view-mode"]:not([class*="title"]) li {
   border-color: #00465c;
 }
 
+.btn:-moz-focusring {
+  outline: 2px dotted;
+}
+
 .nav-tabs {
   border-bottom: 1px solid #ddd;
   margin-top: 10px;

--- a/themes/wim/dist/styleguide/atoms/buttons.html
+++ b/themes/wim/dist/styleguide/atoms/buttons.html
@@ -75,6 +75,7 @@
             <div class="region region-content">
               <section id="block-system-main" class="block block-system clearfix">
                 <h1>Buttons</h1><p>Use the button classes on an <code>&lt;a&gt;</code>, <code>&lt;button&gt;</code>, or <code>&lt;input&gt;</code> element. Use logical elements for your buttons. If it is not a link do not use a <code>&lt;button&gt;</code> tag instead. If the <code>&lt;a&gt;</code> elements are used to act as buttons – triggering in-page functionality, rather than navigating to another document or section within the current page – they should also be given an appropriate <code>role=&quot;button&quot;</code>.</p>
+
                 <p><a href="http://getbootstrap.com/css/#buttons">Visit the Bootstrap documentation</a></p>
                 <h3>Demo:</h3>
                 <button type="button" class="btn btn-default">Default</button>

--- a/themes/wim/dist/styleguide/atoms/form-elements.html
+++ b/themes/wim/dist/styleguide/atoms/form-elements.html
@@ -77,6 +77,7 @@
                 <h1>Form elements</h1>
                 <h2>Input</h2>
                 <p><p>Input fields allow user input. The border should light up simply and clearly indicating which field the user is currently editing. You must have put a <code>.form-control</code> class on each input.</p>
+
                 </p>
                 <h3>Demo: </h3>
                 <input type="text" class="form-text form-control">
@@ -84,6 +85,7 @@
                 <pre class="language-html"><code class="language-html">Code</code></pre>
                 <h2>Textarea</h2>
                 <p><p>Textareas allow larger expandable user input. The border should light up simply and clearly indicating which field the user is currently editing. You must have a <code>.form-control</code> class on the textarea element.</p>
+
                 </p>
                 <h3>Demo: </h3>
                 <textarea class="form-textarea form-control"></textarea>
@@ -92,6 +94,7 @@
 Code</code></pre>
                 <h2>Select</h2>
                 <p><p>Select allows user input through specified options. Make sure you add the class <code>.form-control</code> to the select element.</p>
+
                 </p>
                 <h3>Demo: </h3>
                 <select class="form-select form-control">
@@ -103,6 +106,7 @@ Code</code></pre>
                 <pre class="language-html"><code class="language-html">Code</code></pre>
                 <h2>Radio</h2>
                 <p><p>Add radio buttons to a group by adding the name attribute along with the same corresponding value for each of the radio buttons in the group. Create disabled radio buttons by adding the <code>disabled</code> attribute as shown below.</p>
+
                 </p>
                 <h3>Demo: </h3>
                 <div class="form-group">

--- a/themes/wim/dist/styleguide/atoms/typography.html
+++ b/themes/wim/dist/styleguide/atoms/typography.html
@@ -75,6 +75,7 @@
             <div class="region region-content">
               <section id="block-system-main" class="block block-system clearfix">
                 <h1>Typography</h1><p>The standard font WIM uses is <code>Robot Slab</code> and has a fallback to Arial or another sans-serif font. We are using the Google CDN to load the font files. We exposed 2 different font weights in the WIM theme. You can use: 400 and 700</p>
+
                 <h3>Demo:</h3>
                 <p>Font with weight 400</p>
                 <p> <strong>Font with weight 700</strong></p>


### PR DESCRIPTION
Firefox has troubles showing a focus indicator when the focus is on a button. This fix should add an outline on the button when focussed with for example tabbing to it.