### PR TITLE
Feature/wim 1293

### DIFF
--- a/themes/wimbase/templates/node/node--agenda--teaser.tpl.php
+++ b/themes/wimbase/templates/node/node--agenda--teaser.tpl.php
@@ -80,7 +80,7 @@
  * @ingroup templates
  */
 ?>
-<article class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+<article  aria-labelledby="node-<?php print $id?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
   <div class="fields-wrapper">
     <?php print render($content['field_agenda_date']); ?>
     <?php if (!empty($content['field_image'])): ?>
@@ -91,7 +91,7 @@
   </div>
   <div class="teaser-body">
     <?php if (!$page && !empty($title)): ?>
-      <h2<?php print $title_attributes; ?>>
+      <h2 <?php print $title_attributes; ?> id="node-<?php print $id?>">
         <a href="<?php print $node_url; ?>"><?php print $title; ?></a>
       </h2>
     <?php endif;

--- a/themes/wimbase/templates/node/node--news--teaser.tpl.php
+++ b/themes/wimbase/templates/node/node--news--teaser.tpl.php
@@ -80,7 +80,7 @@
  * @ingroup templates
  */
 ?>
-<article class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+<article aria-labelledby="node-<?php print $id?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
   <?php if (!empty($content['field_image'])): ?>
     <div class="teaser-image">
       <?php print render($content['field_image']); ?>
@@ -88,7 +88,7 @@
   <?php endif; ?>
   <div class="teaser-body">
     <?php if (!$page && !empty($title)): ?>
-      <h2<?php print $title_attributes; ?>>
+      <h2<?php print $title_attributes; ?> id="node-<?php print $id?>">
         <a href="<?php print $node_url; ?>"><?php print $title; ?></a>
       </h2>
     <?php endif;


### PR DESCRIPTION
Still waiting for a definitive answer from the accessibility people if this is correct.

But the issue was that the teasers don't have a chronologic order as in, the image is in html above the h2 in news/agenda teasers. I tried to fix this with setting a aria labbeledby. If this is not correct, I will need to adjust the structure to set the H2 at top and the styling that goes with it.