### PR TITLE
WIM-1306 - add the novalidate attribute so HTML5 validation won't mes…

### DIFF
--- a/modules/features/wim_webform/wim_webform.module
+++ b/modules/features/wim_webform/wim_webform.module
@@ -11,6 +11,7 @@ include_once 'wim_webform.features.inc';
  * Implements hook_form_FORM_ID_alter().
  */
 function wim_webform_form_webform_client_form_alter(&$form, $form_state) {
+  $form['#attributes'] = array('novalidate' => 'novalidate');
 
   $form_sets = array(
     'radios',


### PR DESCRIPTION
Add a novalidate to all webforms so browser don't give html5 error handling.

Reason is because they are not accessible and hard to alter.