### PR TITLE
Feature/wim 1302

### DIFF
--- a/modules/features/wim_search/wim_search.facetapi_defaults.inc
+++ b/modules/features/wim_search/wim_search.facetapi_defaults.inc
@@ -73,7 +73,7 @@ function wim_search_facetapi_default_facet_settings() {
   $facet->enabled = TRUE;
   $facet->settings = array(
     'weight' => 0,
-    'widget' => 'facetapi_links',
+    'widget' => 'facetapi_checkbox_links',
     'filters' => array(),
     'active_sorts' => array(
       'display' => 'display',
@@ -181,7 +181,7 @@ function wim_search_facetapi_default_facet_settings() {
   $facet->enabled = TRUE;
   $facet->settings = array(
     'weight' => 0,
-    'widget' => 'date_range',
+    'widget' => 'date_range_checkboxes',
     'filters' => array(),
     'active_sorts' => array(
       'active' => 0,

--- a/themes/wim/components/wim/organisms/_search.scss
+++ b/themes/wim/components/wim/organisms/_search.scss
@@ -149,10 +149,23 @@
       font-size: 13px;
       line-height: 22px;
       color: lighten($gray-base, 40%);
+
+      input[type="checkbox"] {
+        opacity: 0;
+        position: absolute;
+      }
+
+      input[type="checkbox"]:focus + a {
+        outline: 5px auto -webkit-focus-ring-color;
+        outline-color: -webkit-focus-ring-color;
+        outline-style: auto;
+        outline-width: 5px;
+        outline-offset: -2px;
+      }
     }
     a {
       color: lighten($gray-base, 40%);
-      display: inline-block;
+      display: inline-block !important;
       &:before {
         content: "";
         border: 1px solid lighten($gray-base, 90%);

--- a/themes/wim/css/wim.css
+++ b/themes/wim/css/wim.css
@@ -3780,9 +3780,22 @@ ul[class^="custom-list-view-mode"]:not([class*="title"]) li {
   color: #666666;
 }
 
+.block-facetapi ul:not(.contextual-links) li input[type="checkbox"] {
+  opacity: 0;
+  position: absolute;
+}
+
+.block-facetapi ul:not(.contextual-links) li input[type="checkbox"]:focus + a {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-color: -webkit-focus-ring-color;
+  outline-style: auto;
+  outline-width: 5px;
+  outline-offset: -2px;
+}
+
 .block-facetapi ul:not(.contextual-links) a {
   color: #666666;
-  display: inline-block;
+  display: inline-block !important;
 }
 
 .block-facetapi ul:not(.contextual-links) a:before {

--- a/themes/wim/dist/css/wim.css
+++ b/themes/wim/dist/css/wim.css
@@ -3780,9 +3780,22 @@ ul[class^="custom-list-view-mode"]:not([class*="title"]) li {
   color: #666666;
 }
 
+.block-facetapi ul:not(.contextual-links) li input[type="checkbox"] {
+  opacity: 0;
+  position: absolute;
+}
+
+.block-facetapi ul:not(.contextual-links) li input[type="checkbox"]:focus + a {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-color: -webkit-focus-ring-color;
+  outline-style: auto;
+  outline-width: 5px;
+  outline-offset: -2px;
+}
+
 .block-facetapi ul:not(.contextual-links) a {
   color: #666666;
-  display: inline-block;
+  display: inline-block !important;
 }
 
 .block-facetapi ul:not(.contextual-links) a:before {

--- a/themes/wim/dist/styleguide/atoms/buttons.html
+++ b/themes/wim/dist/styleguide/atoms/buttons.html
@@ -75,6 +75,7 @@
             <div class="region region-content">
               <section id="block-system-main" class="block block-system clearfix">
                 <h1>Buttons</h1><p>Use the button classes on an <code>&lt;a&gt;</code>, <code>&lt;button&gt;</code>, or <code>&lt;input&gt;</code> element. Use logical elements for your buttons. If it is not a link do not use a <code>&lt;button&gt;</code> tag instead. If the <code>&lt;a&gt;</code> elements are used to act as buttons – triggering in-page functionality, rather than navigating to another document or section within the current page – they should also be given an appropriate <code>role=&quot;button&quot;</code>.</p>
+
                 <p><a href="http://getbootstrap.com/css/#buttons">Visit the Bootstrap documentation</a></p>
                 <h3>Demo:</h3>
                 <button type="button" class="btn btn-default">Default</button>

--- a/themes/wim/dist/styleguide/atoms/form-elements.html
+++ b/themes/wim/dist/styleguide/atoms/form-elements.html
@@ -77,6 +77,7 @@
                 <h1>Form elements</h1>
                 <h2>Input</h2>
                 <p><p>Input fields allow user input. The border should light up simply and clearly indicating which field the user is currently editing. You must have put a <code>.form-control</code> class on each input.</p>
+
                 </p>
                 <h3>Demo: </h3>
                 <input type="text" class="form-text form-control">
@@ -84,6 +85,7 @@
                 <pre class="language-html"><code class="language-html">Code</code></pre>
                 <h2>Textarea</h2>
                 <p><p>Textareas allow larger expandable user input. The border should light up simply and clearly indicating which field the user is currently editing. You must have a <code>.form-control</code> class on the textarea element.</p>
+
                 </p>
                 <h3>Demo: </h3>
                 <textarea class="form-textarea form-control"></textarea>
@@ -92,6 +94,7 @@
 Code</code></pre>
                 <h2>Select</h2>
                 <p><p>Select allows user input through specified options. Make sure you add the class <code>.form-control</code> to the select element.</p>
+
                 </p>
                 <h3>Demo: </h3>
                 <select class="form-select form-control">
@@ -103,6 +106,7 @@ Code</code></pre>
                 <pre class="language-html"><code class="language-html">Code</code></pre>
                 <h2>Radio</h2>
                 <p><p>Add radio buttons to a group by adding the name attribute along with the same corresponding value for each of the radio buttons in the group. Create disabled radio buttons by adding the <code>disabled</code> attribute as shown below.</p>
+
                 </p>
                 <h3>Demo: </h3>
                 <div class="form-group">

--- a/themes/wim/dist/styleguide/atoms/typography.html
+++ b/themes/wim/dist/styleguide/atoms/typography.html
@@ -75,6 +75,7 @@
             <div class="region region-content">
               <section id="block-system-main" class="block block-system clearfix">
                 <h1>Typography</h1><p>The standard font WIM uses is <code>Robot Slab</code> and has a fallback to Arial or another sans-serif font. We are using the Google CDN to load the font files. We exposed 2 different font weights in the WIM theme. You can use: 400 and 700</p>
+
                 <h3>Demo:</h3>
                 <p>Font with weight 400</p>
                 <p> <strong>Font with weight 700</strong></p>

--- a/themes/wimbase/js/accessibility-tabs.js
+++ b/themes/wimbase/js/accessibility-tabs.js
@@ -19,7 +19,7 @@
       home: 36,
       tab: 9
     };
-    
+
     var $tablist = $('.tabnav ul', context);
 
     // Do nothing if there are no tabs.
@@ -85,7 +85,6 @@
 
       if (i !== 0) {
         $link.attr('aria-selected', 'false');
-        $link.attr('tabindex', '-1');
       } else {
         $link.attr('aria-selected', 'true');
         $link.attr('tabindex', '0');
@@ -99,7 +98,7 @@
    * @param {Boolean} click Determines if click is needed.
    */
   Drupal.wcagTabs.switchTabs = function ($newTab, click) {
-    $newTab.siblings().find('a').attr('tabindex', '-1').attr('aria-selected', 'false');
+    $newTab.siblings().find('a').attr('aria-selected', 'false');
 
     var $newTabLink = $newTab.find('a');
 

--- a/themes/wimbase/js/wim.js
+++ b/themes/wimbase/js/wim.js
@@ -72,4 +72,12 @@
     }
   };
 
+  // Global behaviour to set checkbox href links to tabindex -1.
+  // Since this is handled by input checkbox.
+  Drupal.behaviors.checkboxTabindex = {
+    attach: function (context, settings) {
+      $("a.facetapi-checkbox").attr("tabindex","-1");
+    }
+  };
+
 })(jQuery);


### PR DESCRIPTION
Change the search page filters. 

They were styled as checkboxes but not accessible as checboxes so changed the facetapi type to real checkboxes and style accordingly.

Should be accessible by using tab to focus them and then spacebar to active the checkbox.