### PR TITLE
Update WIM 2.0 default password policy to use punctuation in password.

### DIFF
--- a/wim.install
+++ b/wim.install
@@ -451,6 +451,7 @@ function _wim_password_policy_default_profile() {
       'digit' => '1',
       'history' => '6',
       'length' => '8',
+      'punctuation' => '1',
       'uppercase' => '1',
     ),
     'expiration' => 60,
@@ -752,6 +753,8 @@ function _wim_permissions($role) {
     'webmaster' => array(
       // System.
       'access administration menu',
+      'administer url aliases',
+      'create url aliases',
       'access administration pages',
       'access content overview',
       'access user profiles',
@@ -877,6 +880,8 @@ function _wim_permissions($role) {
     'content manager' => array(
       // System.
       'access administration menu',
+      'create url aliases',
+      'administer url aliases',
       'access administration pages',
       'access content overview',
       'access user profiles',
@@ -988,6 +993,7 @@ function _wim_permissions($role) {
     'content editor' => array(
       // System.
       'use text format filtered_html',
+      'create url aliases',
       'use text format full_html',
       'view the administration theme',
       'view own unpublished content',

--- a/wim.update.inc
+++ b/wim.update.inc
@@ -208,3 +208,19 @@ function wim_update_7008(&$sandbox) {
     return "Could not find role";
   }
 }
+
+/**
+ * Update WIM 2.0 default password policy to use punctuation in password.
+ */
+function wim_update_7009() {
+  $policy = password_policy_policy_load(1);
+  $policy['policy']['punctuation'] = '1';
+  db_update('password_policy')->fields(array(
+    'name' => $policy['name'],
+    'description' => $policy['description'],
+    'enabled' => $policy['enabled'],
+    'policy' => serialize($policy['policy']),
+    'expiration' => $policy['expiration'],
+    'warning' => $policy['warning'],
+  ))->condition('pid', 1)->execute();
+}


### PR DESCRIPTION
This is a fix for `Password creation - Special Characters is missing`

Special Characters is missing from the mandatory requirements when adding a password to an account.

Updated profile to fix this, also update provided.