### PR TITLE
Change insert method for urls from Raw paths to Alias paths.

### DIFF
--- a/modules/features/wim_text_formats/wim_text_formats.linkit_profiles.inc
+++ b/modules/features/wim_text_formats/wim_text_formats.linkit_profiles.inc
@@ -86,7 +86,7 @@ function wim_text_formats_default_linkit_profiles() {
       'result_description' => '',
     ),
     'insert_plugin' => array(
-      'url_method' => '2',
+      'url_method' => '3',
     ),
     'attribute_plugins' => array(
       'alt' => array(


### PR DESCRIPTION
By default in our settings Linkit inserting urls like Raw paths, with a slash (/) in the beginning.
These will work without the need for an input filter, but might fail after moving a site, or on multilingual sites.
So the best way is to use Alias paths.
I think it will be better.