### PR TITLE
Fix novalidate bug issue #397.

### DIFF
--- a/modules/features/wim_webform/wim_webform.module
+++ b/modules/features/wim_webform/wim_webform.module
@@ -11,7 +11,7 @@ include_once 'wim_webform.features.inc';
  * Implements hook_form_FORM_ID_alter().
  */
 function wim_webform_form_webform_client_form_alter(&$form, $form_state) {
-  $form['#attributes'] = array('novalidate' => 'novalidate');
+  $form['#attributes']['novalidate'] = 'novalidate';
 
   $form_sets = array(
     'radios',


### PR DESCRIPTION
Assigning a new array erase previous state for #attributes, fixed.