### PR TITLE
WIM-1293 by robertragas - Put back code to show more descriptive text…

### DIFF
--- a/modules/custom/custom_lists/custom_lists.module
+++ b/modules/custom/custom_lists/custom_lists.module
@@ -138,7 +138,7 @@ function custom_lists_block_view($delta = '') {
     $more_link_uri = custom_lists_get_more_uri($list);
     if ($more_link_uri) {
       $block['content']['more-link'] = array(
-        '#markup' => '<div class="more-link">' . l(t('More'), $more_link_uri) . '</div>',
+        '#markup' => '<div class="more-link">' . l(t('More @display_title', array('@display_title' => $list['display_title'])), $more_link_uri) . '</div>',
       );
     }
   }


### PR DESCRIPTION
I think we accidently overridden this in another PR. This was already in but got reverted.
@kedramon @ozin7 did one of you revert this in purpose? Otherwise it can be merged again.

It gives more descriptive read more link of what the user can expect.