### PR TITLE
Fixing missing column on install error

### DIFF
--- a/wim.install
+++ b/wim.install
@@ -471,7 +471,7 @@ function _wim_password_policy_install() {
       'name' => $profile['name'],
       'description' => $profile['description'],
       'enabled' => $profile['enabled'],
-      'policy' => serialize($profile['policy']),
+      'constraints' => serialize($profile['constraints']),
       'expiration' => $profile['expiration'],
       'warning' => $profile['warning'],
     ))->execute();
@@ -499,7 +499,7 @@ function _wim_password_policy_default_profile() {
     'name' => 'default',
     'description' => t('WIM 2.0 default password policy'),
     'enabled' => TRUE,
-    'policy' => array(
+    'constraints' => array(
       'character_types' => '1',
       'digit' => '1',
       'history' => '6',


### PR DESCRIPTION
Due to update in password_policy module `password_policy_update_7106()` we need to rename the field. 

> Rename "policy" of {password_policy} to "constraints"