### PR TITLE
WIM2DISTRO-133 client verification of cookie consent data

### DIFF
--- a/modules/custom/cookie_consent/cookie_consent.module
+++ b/modules/custom/cookie_consent/cookie_consent.module
@@ -89,7 +89,7 @@ function _cookie_consent_attach(&$page) {
   }
 
   // We cannot use Drupal.settings, because the cookie compliance
-  // script must kick in before the Druapl.settings object is added to the page.
+  // script must kick in before the Drupal.settings object is added to the page.
   $options = array(
     'style' => variable_get('cookie_consent_style', 'monochrome'),
     'ip' => ip_address(),
@@ -151,22 +151,30 @@ function cookie_consent_cookie_consent_categories() {
 function cookie_consent_add() {
   global $user;
 
-  if (!isset($_GET['type']) or !isset($_GET['value']) or !isset($_GET['ip'])) {
+  if (!isset($_GET['type']) || !isset($_GET['value'])) {
     return drupal_access_denied();
   }
 
+  // Format value and determine the allowed values.
+  $value = intval(check_plain($_GET['value']));
+  $allowed_values = [
+    0,
+    1,
+  ];
+
+  // Format the type value and fetch the allowed types.
   $cookies = _cookie_consent_get_categories();
   $type = check_plain($_GET['type']);
 
-  // Check if we have this type defined.
-  if (!isset($cookies[str_replace('cc_', '', $type)])) {
+  // Validate the client values.
+  if (!in_array($value, $allowed_values) || !isset($cookies[str_replace('cc_', '', $type)])) {
     return drupal_access_denied();
   }
 
   $record = (object) array(
-    'ip' => check_plain($_GET['ip']),
+    'ip' => ip_address(),
     'type' => $type,
-    'value' => check_plain($_GET['value']),
+    'value' => $value,
     'changed' => time(),
   );
 


### PR DESCRIPTION
We no longer let the client tell us which IP address it has. We
populate this value on the server side anyway so it makes more
sense to do this when we insert the cookie into the database. This
prevents users changing cookie settings for other IPs.

We now validate the value that is being set for the cookie. This
ensures that random values can't be entered into the database.

##  How to test

- Try to send random data to the AJAX end point and see that it gets stored in the database
- Check out this code
- Send the same random data to the AJAX end point and see that it no longer gets stored in the database