### PR TITLE
by robertragas: add submit names to block usage form so translations …

### DIFF
--- a/modules/features/wim_block_management/includes/block_usage.forms.inc
+++ b/modules/features/wim_block_management/includes/block_usage.forms.inc
@@ -112,7 +112,7 @@ function block_usage_filters() {
   $form['block_usage_filter']['actions']['apply'] = [
     '#type' => 'submit',
     '#value' => t('Apply'),
-    '#name' => 'apply_filter'
+    '#name' => 'apply_filter',
   ];
 
   $form['block_usage_filter']['actions']['reset'] = [
@@ -138,7 +138,6 @@ function block_usage_filters() {
 function block_usage_filters_submit(&$form, &$form_state) {
   // Get the query string parameters minus the drupal url and filter param.
   $params = drupal_get_query_parameters($_GET, ['q', 'filter']);
-
 
   // Add the filters to the query string.
   $filters = [

--- a/modules/features/wim_block_management/includes/block_usage.forms.inc
+++ b/modules/features/wim_block_management/includes/block_usage.forms.inc
@@ -112,11 +112,13 @@ function block_usage_filters() {
   $form['block_usage_filter']['actions']['apply'] = [
     '#type' => 'submit',
     '#value' => t('Apply'),
+    '#name' => 'apply_filter'
   ];
 
   $form['block_usage_filter']['actions']['reset'] = [
     '#type' => 'submit',
     '#value' => t('Reset'),
+    '#name' => 'reset_filter',
   ];
 
   return $form;
@@ -137,6 +139,7 @@ function block_usage_filters_submit(&$form, &$form_state) {
   // Get the query string parameters minus the drupal url and filter param.
   $params = drupal_get_query_parameters($_GET, ['q', 'filter']);
 
+
   // Add the filters to the query string.
   $filters = [
     'type' => implode(',', $form_state['values']['block_usage_filter_type']),
@@ -145,18 +148,16 @@ function block_usage_filters_submit(&$form, &$form_state) {
     'status' => $form_state['values']['block_usage_status'],
   ];
 
-  switch (strtolower($form_state['values']['op'])) {
-    case 'apply':
-      foreach ($filters as $filter_name => $filter_value) {
-        if (!empty($filter_value)) {
-          $params[$filter_name] = $filter_value;
-        }
+  if ($form_state['values']['apply_filter']) {
+    foreach ($filters as $filter_name => $filter_value) {
+      if (!empty($filter_value)) {
+        $params[$filter_name] = $filter_value;
       }
-      break;
+    }
+  }
 
-    case 'reset':
-      $params = [];
-      break;
+  if ($form_state['values']['reset_filter']) {
+    $params = [];
   }
 
   // Redirect back to block usage view with added filter query string param.


### PR DESCRIPTION
When using the filter currently on block usage it looks at the operation name to decide what to do. 
This is within a t() function which causes dutch sites to not apply filters because they are named "Toepassen". I added field names so we can use that to decide the operation.