### PR TITLE
WIMDISTRO-154 by robertragas: if the sduconnect is empty but the fiel…

### DIFF
--- a/modules/features/sduconnect/sduconnect.content.inc
+++ b/modules/features/sduconnect/sduconnect.content.inc
@@ -520,6 +520,10 @@ function sduconnect_set_vac_content($xpath, &$node, $private = FALSE) {
   if ($items) {
     $node->field_faq_more_information = array(LANGUAGE_NONE => $items);
   }
+  elseif (empty($items) && !empty($node->field_faq_more_information)) {
+    unset($node->field_faq_more_information);
+    $node->field_faq_more_information = array();
+  }
 
   // Related Product items.
   $items = sduconnect_nodelist_to_array($xpath->query('//vac:vacs/vac:vac/vac:body/vac:verwijzingProduct/@resourceIdentifier'));


### PR DESCRIPTION
HTT

1. Use SDUconnect to create a FAQ with the "more information" field filled in.
2. Import SDU in Drupal and see the FAQ gets created with content in this field.
3. Remove the more information field again from SDUconnect and re-run the updates.
4. Notice the field now gets emptied.