### PR TITLE
Library ckeditor-4.8.0-full to ckeditor-4.14.0-full

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -179,9 +179,9 @@ libraries[slick][download][url] = https://github.com/kenwheeler/slick/archive/1.
 libraries[chosen][download][type] = get
 libraries[chosen][download][url] = https://github.com/harvesthq/chosen/releases/download/v1.6.2/chosen_v1.6.2.zip
 
-; CKEditor 4.8.0
+; CKEditor 4.14.0
 libraries[ckeditor][download][type] = get
-libraries[ckeditor][download][url] = https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.8.0/ckeditor_4.8.0_full.zip
+libraries[ckeditor][download][url] = https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.14.0/ckeditor_4.14.0_full.zip
 
 ; Apachesolr attachments
 projects[apachesolr_attachments][patch][2677866] = https://www.drupal.org/files/issues/mysql-56-compatibility-2677866-12.patch


### PR DESCRIPTION
Updating the library as followup on https://www.drupal.org/sa-contrib-2020-007