### PR TITLE
Dimpact 4

### DIFF
--- a/modules/features/wim_block_management/wim_block_management.module
+++ b/modules/features/wim_block_management/wim_block_management.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Code for the WIM Block Management feature.
@@ -177,9 +178,9 @@ function wim_block_management_form_felix_remove_form_alter(&$form, &$form_state,
     $region = $form['#felix_region'];
     $form['info'] = [
       '#markup' => '<p>' . t('Are you sure you want to delete the block %subject from %region?', [
-          '%subject' => strip_tags($block->subject),
-          '%region' => $region->title,
-        ]) . '</p>',
+        '%subject' => strip_tags($block->subject),
+        '%region' => $region->title,
+      ]) . '</p>',
     ];
   }
 }
@@ -268,15 +269,14 @@ function wim_block_management_form_block_admin_configure_alter(&$form, &$form_st
     '#type' => 'textfield',
     '#title' => t('Aria label'),
     '#default_value' => $additional_settings['aria_label'],
-    '#description' => t('Text for \'aria-label\' attribute.'),
+    '#description' => t("Text for 'aria-label' attribute."),
   ];
 
   $form['#submit'][] = 'wim_block_management_form_block_admin_configure_submit';
 }
 
 /**
- * Form submission handler for
- * wim_block_management_form_block_admin_configure_alter().
+ * Form submission handler.
  *
  * @see wim_block_management_form_block_admin_configure_alter()
  */
@@ -305,7 +305,9 @@ function wim_block_management_form_block_admin_configure_submit($form, &$form_st
  * Gets additional settings for block.
  *
  * @param string $module
+ *   Module machine name.
  * @param string $delta
+ *   Block delta.
  *
  * @return array
  *   WIM additional settings for block.

--- a/modules/features/wim_block_management/wim_block_management.module
+++ b/modules/features/wim_block_management/wim_block_management.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Code for the WIM Block Management feature.
@@ -177,9 +178,9 @@ function wim_block_management_form_felix_remove_form_alter(&$form, &$form_state,
     $region = $form['#felix_region'];
     $form['info'] = [
       '#markup' => '<p>' . t('Are you sure you want to delete the block %subject from %region?', [
-          '%subject' => strip_tags($block->subject),
-          '%region' => $region->title,
-        ]) . '</p>',
+        '%subject' => strip_tags($block->subject),
+        '%region' => $region->title,
+      ]) . '</p>',
     ];
   }
 }
@@ -268,15 +269,14 @@ function wim_block_management_form_block_admin_configure_alter(&$form, &$form_st
     '#type' => 'textfield',
     '#title' => t('Aria label'),
     '#default_value' => $additional_settings['aria_label'],
-    '#description' => t('Text for \'aria-label\' attribute.'),
+    '#description' => t("Text for 'aria-label' attribute."),
   ];
 
   $form['#submit'][] = 'wim_block_management_form_block_admin_configure_submit';
 }
 
 /**
- * Form submission handler for
- * wim_block_management_form_block_admin_configure_alter().
+ * Custom form submission handler.
  *
  * @see wim_block_management_form_block_admin_configure_alter()
  */
@@ -305,7 +305,9 @@ function wim_block_management_form_block_admin_configure_submit($form, &$form_st
  * Gets additional settings for block.
  *
  * @param string $module
+ *   Module machine name.
  * @param string $delta
+ *   Block delta.
  *
  * @return array
  *   WIM additional settings for block.

--- a/modules/features/wim_block_management/wim_block_management.module
+++ b/modules/features/wim_block_management/wim_block_management.module
@@ -242,7 +242,7 @@ function get_modules_usage_blocks() {
  * @see block_admin_configure()
  */
 function wim_block_management_form_block_add_block_form_alter(&$form, &$form_state, $form_id) {
-  wim_block_management_form_block_admin_configure_alter($form, $form_state);
+  wim_block_management_form_block_admin_configure_alter($form, $form_state, $form_id);
 }
 
 /**


### PR DESCRIPTION
Fixes error:
`ArgumentCountError: Too few arguments to function wim_block_management_form_block_admin_configure_alter(), 2 passed in /app/html/profiles/wim/modules/features/wim_block_management/wim_block_management.module on line 245 and exactly 3 expected in wim_block_management_form_block_admin_configure_alter() (regel 255 van /app/html/profiles/wim/modules/features/wim_block_management/wim_block_management.module).`