### PR TITLE
Possible fix invalid header check

### DIFF
--- a/modules/custom/wim_cvdr/wim_cvdr.module
+++ b/modules/custom/wim_cvdr/wim_cvdr.module
@@ -182,7 +182,7 @@ function _wim_cvdr_read_xml() {
       // Request the XML from the webservice.
       $xml_response = drupal_http_request($xml_url, ['timeout' => 6]);
 
-      if ($xml_response->code !== '200' || strpos($xml_response->headers['content-type'], 'application/xml') === FALSE) {
+      if ($xml_response->code !== '200' || strpos($xml_response->headers['Content-Type'], 'application/xml') === FALSE) {
         // Log error and quit.
         watchdog('WIM CVDR',
           'Could not retrieve XML. Debug: !array',


### PR DESCRIPTION
Response headers are usually sent back in Camel Case from the CDVR API.